### PR TITLE
Resolved the conflict between the Dynamixel item name, buying link, and specs in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Video of the assembly: https://youtu.be/RckrXOEoWrk
 
 | Part                          | Cost | Buying link | Specs |
 |-------------------------------|------| --- | --- |
-| 6x Dynamixel XL330-W077       | $144 |  https://www.robotis.us/dynamixel-xl330-m077-t/ | https://emanual.robotis.com/docs/en/dxl/x/xl330-m077/|
+| 6x Dynamixel XL330-M077       | $144 |  https://www.robotis.us/dynamixel-xl330-m077-t/ | https://emanual.robotis.com/docs/en/dxl/x/xl330-m077/|
 | XL330 Frame | $7   | https://www.robotis.us/fpx330-s101-4pcs-set/ | |
 | XL330 Idler Wheel             | $10  | https://www.robotis.us/fpx330-h101-4pcs-set/   | **Note**: pack of four; three needed for longer version (with elbow-to-wrist extension), two needed for shorter version pictured below |
 | Waveshare Serial Bus Servo Driver Board | $10  | https://a.co/d/7C3RUYU | |


### PR DESCRIPTION
### Description:
This Pull Request (PR) resolves a discrepancy in the README.md where the buying link and specifications listed are for the XL330-M077, but the Part column incorrectly references XL330-W077.

### Changes Made:
Updated the README.md to correct the first part of listed material for leader arm, changing it from XL330-W077 to XL330-M077.