### PR TITLE
Adding buying links for europeans.

### DIFF
--- a/LINKS_EU.md
+++ b/LINKS_EU.md
@@ -1,11 +1,13 @@
-# $250 Robot Arm
+# $250 Robot Arm European Purchasing Links
 
-Those are buying links for europeans, please read the [README](README.md)
+These are purchasing links for Europeans. Please refer to the [README](README.md) for further information.
 
 ## Follower Arm
 
 ### Required Materials
-For the amazon links below, change the .fr to **your country's domain**.
+
+For the Amazon links below, replace ".fr" with **your country's domain**.
+
 | Part                          | Cost | Buying link                                    | Specs |
 |-------------------------------|------|------------------------------------------------| --- |
 | 2x Dynamixel XL430-W250       | 100€ | https://robosavvy.co.uk/dynamixel-xl430-w250-t.html | https://emanual.robotis.com/docs/en/dxl/x/xl430-w250/ |
@@ -18,18 +20,19 @@ For the amazon links below, change the .fr to **your country's domain**.
 | Table Clamp                   | 16€   | https://amazon.fr/dp/B09GW56Y44/                         | | **Note**: pack of two, buying this to have the table clamp for both arms, if you only need one, cheaper options are readily available.|
 | Wires                         | 7€   | https://amazon.fr/gp/product/B0B1PD6SRH/
 | Total                         | 269€ | | **Note**: There will be around 20€ transport fees, this number will differ from one country to another. |
-For the amazon links, change the .fr to your country's domain.
 
 ![follower](./pictures/follower_arm.png)
 
 ## Leader Arm
 
 ### Required Materials
-For the amazon links below, change the .fr to **your country's domain**.
+
+For the Amazon links below, replace ".fr" with **your country's domain**.
+
 | Part                          | Cost | Buying link | Specs |
 |-------------------------------|------| --- | --- |
 | 6x Dynamixel XL330-M077       | 153€ |  https://robosavvy.co.uk/robotis-dynamixel-xl330-m077-t.html | https://emanual.robotis.com/docs/en/dxl/x/xl330-m077/|
-| XL330 Frame | 15€   | https://www.mybotshop.de/DYNAMIXEL-FPX330-S101-4PCS-Set_3 | | **Note**: currently not avalible on robosavvy
+| XL330 Frame | 15€   | https://www.mybotshop.de/DYNAMIXEL-FPX330-S101-4PCS-Set_3 | **Note**: currently not avalible on robosavvy|
 | XL330 Idler Wheel             | 11€  | https://robosavvy.co.uk/fpx330-h101-4pcs-set.html   | **Note**: pack of four; three needed for longer version (with elbow-to-wrist extension), two needed for shorter version pictured below |
 | Waveshare Serial Bus Servo Driver Board | 10€  | https://amazon.fr/gp/product/B0CJ6TP3TP/
 | 5V Power Supply               | 10€   | https://amazon.fr/gp/product/B09NGVWBSY/ | |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The robot arm can be controlled with the Dynamixel SDK: ```pip install dynamixel
 
 There is usually a 10% discount code for the Robotis shop. It might also help to add some grip tape to the gripper (e.g. https://a.co/d/dW7BnEN). A USB-C cable is necessary to connect the servo driver board to a computer.
 
-For europeans, the buying links above might not be able to ship to your country. In that case, check the [EU version](LINKS_EU.md).
+For Europeans, the buying links above may not be able to ship to your country. If that's the case, please check the [EU version](LINKS_EU.md).
 
 ![follower](./pictures/follower_arm.png)
 
@@ -72,6 +72,8 @@ Video of the assembly: https://youtu.be/RckrXOEoWrk
 | 5V Power Supply               | $6   | https://a.co/d/5u90NVp | |
 | Table Clamp                   | $6   | https://a.co/d/4KEiYdV | |
 | Total                        | $183 | | |
+
+For Europeans, the buying links above may not be able to ship to your country. If that's the case, please check the [EU version](LINKS_EU.md).
 
 ![leader](./pictures/leader_arm.png)
 


### PR DESCRIPTION
This pull request updates the README.md file to include buying links specifically tailored for European users. The existing links were not functional for European users, so I added alternative links that direct to EU-based sellers. This change aims to improve accessibility and user experience for European audiences. This change adds only two lines to the README.md file and redirects to another file, ensuring that readability for other users remains unaffected.